### PR TITLE
Fix: Correct Mermaid syntax for subgraphs in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ graph TD
     B -->|Commands, Control, Data| C(PLAXIS Interactor (Python)<br>(src/backend/plaxis_interactor/interactor.py))
     C -->|Python Scripting API / CLI| D(PLAXIS 3D Software)
 
-    subgraph A [User Interface (Frontend)]
+    subgraph FE ["User Interface (Frontend)"]
         direction TB
         A1[Project Management (New, Save, Load)]
         A2[Input Widgets (Spudcan Geometry, Soil, Loading, Analysis Ctrl)]
@@ -57,7 +57,7 @@ graph TD
         A5[Configuration Dialog]
     end
 
-    subgraph B [Backend Logic (Python)]
+    subgraph BL ["Backend Logic (Python)"]
         direction TB
         B1[Data Models (ProjectSettings, SpudcanGeometry, SoilLayer, etc.)]
         B2[Project I/O (Save/Load JSON - project_io.py)]
@@ -65,7 +65,7 @@ graph TD
         B4[Analysis Worker (QThread in main_window.py to manage interactor)]
     end
 
-    subgraph C [PLAXIS Interactor (Python)]
+    subgraph PI ["PLAXIS Interactor (Python)"]
         direction TB
         C1[Manages connection to PLAXIS (Input/Output servers via plxscripting)]
         C2[Translates UI data into PLAXIS API commands (using builder modules)<br>- Geometry Builder<br>- Soil Builder<br>- Calculation Builder]


### PR DESCRIPTION
Changed subgraph definitions to use unique IDs and quoted titles to resolve parsing errors when rendering the diagram on GitHub.